### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu
 MAINTAINER cylia-1993 (cylia.sell@gmail.com) 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nginx git
+RUN apt-get update && apt-get install -y \
+  nginx \
+  git \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -Rf /var/www/html/*
 EXPOSE 80
 #ADD static-website-example/ /var/www/html/
-RUn rm -Rf /var/www/html/*
 RUN git clone https://github.com/diranetafen/static-website-example.git /var/www/html
 ENTRYPOINT ["/usr/sbin/nginx", "-q", "deamon off;"]


### PR DESCRIPTION
Docker is using a layer behavior, try to put as much as possible inside the same layer.
`rm` inside a layer just "add" information that it must be removed, it doesn't make image smaller.
Layer are cached, so first `apt-get update` can be really late (because cached) when second layer `apt-get install` is ran.